### PR TITLE
Feature/adjust output format

### DIFF
--- a/DeviceHiveESP8266.md
+++ b/DeviceHiveESP8266.md
@@ -231,7 +231,9 @@ This is auxiliary command that is used to get a list of supported commands. This
 and output looks like:
 
 ```json
-[
+{
+ "commands":
+ [
   "gpio/write",
   "gpio/read",
   "gpio/int",
@@ -243,7 +245,8 @@ and output looks like:
   "uart/int",
   "uart/terminal",
   ...
-]
+ ]
+}
 ```
 
 The `command/list` command is used on the `tryapi.html` page to provide command suggestion.

--- a/firmware-src/sources/dhcommands.c
+++ b/firmware-src/sources/dhcommands.c
@@ -228,7 +228,7 @@ static void ICACHE_FLASH_ATTR do_handle_command_list(COMMAND_RESULT *cmd_res, co
                                                      const char *params, unsigned int params_len)
 {
 	// estimate memory space
-	int i, n = 2; // note []
+	int i, n = 15; // note {"commands":[]}
 	for (i = 0; i < NUM_OF_COMMANDS; ++i) {
 		n += os_strlen(g_command_table[i].name) + 2+1; // note ,""
 	}
@@ -242,7 +242,7 @@ static void ICACHE_FLASH_ATTR do_handle_command_list(COMMAND_RESULT *cmd_res, co
 
 	// format response
 	char *p = (char*)buf;
-	*p++ = '[';
+	p += snprintf(p, n, "%s", "{\"commands\":[");
 	for (i = 0; i < NUM_OF_COMMANDS; ++i) {
 		if (i) *p++ = ',';
 		*p++ = '"';
@@ -251,6 +251,7 @@ static void ICACHE_FLASH_ATTR do_handle_command_list(COMMAND_RESULT *cmd_res, co
 		*p++ = '"';
 	}
 	*p++ = ']';
+	*p++ = '}';
 	*p = 0; // guard
 
 	cmd_res->callback(cmd_res->data,

--- a/firmware-src/sources/dhconnector_websocket_api.c
+++ b/firmware-src/sources/dhconnector_websocket_api.c
@@ -189,6 +189,10 @@ int ICACHE_FLASH_ATTR dhconnector_websocket_api_communicate(const char *in, unsi
 			return DHCONNECT_WEBSOCKET_API_ERROR;
 		}
 		connected = 1;
+	} else if(os_strcmp(action, "command/update") == 0) {
+		if(status_not_success) {
+			dhdebug("Failed to update command: %s", error);
+		}
 	}
 	return 0;
 }

--- a/firmware-src/sources/dhsender_data.c
+++ b/firmware-src/sources/dhsender_data.c
@@ -104,7 +104,7 @@ int ICACHE_FLASH_ATTR dhsender_data_to_json(char *buf, unsigned int buf_len,
 		case RDT_FORMAT_JSON:
 			return snprintf(buf, buf_len, "%s", data->array); // TODO: strncpy to simple string copy!
 		case RDT_CONST_STRING:
-			return snprintf(buf, buf_len, "\"%s\"", data->string);
+			return snprintf(buf, buf_len, "{\"value\":\"%s\"}", data->string);
 		case RDT_DATA_WITH_LEN:
 		{
 			const unsigned int pos = snprintf(buf, buf_len, "{\"data\":\"");


### PR DESCRIPTION
the latest playground changes require the notification's `parameters`  and command's `result` to be JSON object instead of more generic JSON value.