### PR TITLE
Feature/secure websockets

### DIFF
--- a/firmware-src/Makefile
+++ b/firmware-src/Makefile
@@ -13,7 +13,7 @@ TARGETAR		= $(OBJDIR)/devicehive.a
 TARGETELF		= $(OBJDIR)/devicehive.elf
 INCLUDEDIRS		= $(addprefix -I,$(SDKPATH)/include $(CURDIR)/sources)
 LIBDIR			= $(addprefix -L,$(SDKPATH)/lib)
-LIBS			= $(addprefix -l,c gcc phy pp net80211 lwip wpa main json crypto)
+LIBS			= $(addprefix -l,c gcc phy pp net80211 lwip wpa main json crypto ssl)
 SOURCES			= $(wildcard sources/*.c) $(wildcard drivers/*.c) $(wildcard sources/devices/*.c) $(wildcard sources/DH/*.c) $(wildcard sources/commands/*.c)
 OBJECTS			= $(addprefix $(OBJDIR)/, $(SOURCES:%.c=%.o))
 GITVER			= $(shell git rev-parse HEAD 2> /dev/null || echo \"not a git repo\")

--- a/firmware-src/Makefile
+++ b/firmware-src/Makefile
@@ -13,7 +13,7 @@ TARGETAR		= $(OBJDIR)/devicehive.a
 TARGETELF		= $(OBJDIR)/devicehive.elf
 INCLUDEDIRS		= $(addprefix -I,$(SDKPATH)/include $(CURDIR)/sources)
 LIBDIR			= $(addprefix -L,$(SDKPATH)/lib)
-LIBS			= $(addprefix -l,c gcc phy pp net80211 lwip wpa main json crypto ssl)
+LIBS			= $(addprefix -l,c gcc phy pp net80211 lwip wpa main json crypto)
 SOURCES			= $(wildcard sources/*.c) $(wildcard drivers/*.c) $(wildcard sources/devices/*.c) $(wildcard sources/DH/*.c) $(wildcard sources/commands/*.c)
 OBJECTS			= $(addprefix $(OBJDIR)/, $(SOURCES:%.c=%.o))
 GITVER			= $(shell git rev-parse HEAD 2> /dev/null || echo \"not a git repo\")
@@ -23,6 +23,18 @@ CC				= $(CROSS_COMPILE)gcc
 AR				= $(CROSS_COMPILE)ar
 SIZE			= $(CROSS_COMPILE)size
 PAGESH			= pages/pages.h
+
+# make SSL=on enables HTTPS/WSS support
+ifneq (,$(filter ${SSL},on yes 1))
+LIBS			+= $(addprefix -l,ssl)
+CFLAGS			+= -DDH_USE_SSL
+
+# if SSL is enabled the firmware size is too big to fit available space
+# so we need to disable all supported devices enabled implicitly.
+# some of them still can be enabled by defining corresponding macro (see user_config.h)
+CFLAGS			+= -DDH_NO_IMPLICIT_DEVICES
+endif
+
 
 .PHONY: all flash full_flash terminal clean disassemble reboot
 

--- a/firmware-src/sources/base64.c
+++ b/firmware-src/sources/base64.c
@@ -44,25 +44,25 @@ static inline int ICACHE_FLASH_ATTR base64_table(uint32_t reg, int offset)
 
 
 /*
- * base64_encode_length() implementation.
+ * esp_base64_encode_length() implementation.
  */
-size_t ICACHE_FLASH_ATTR base64_encode_length(size_t data_len)
+size_t ICACHE_FLASH_ATTR esp_base64_encode_length(size_t data_len)
 {
 	return (data_len + 2)/3 * 4; // round_up(len/3)*4
 }
 
 
 /*
- * base64_encode() implementation.
+ * esp_base64_encode() implementation.
  */
-int ICACHE_FLASH_ATTR base64_encode(const void *data_, size_t data_len,
-                                    char *text, size_t text_len)
+int ICACHE_FLASH_ATTR esp_base64_encode(const void *data_, size_t data_len,
+                                        char *text, size_t text_len)
 {
 	if (!data_len)
 		return 0; // nothing to encode
 
 	// check we have enough space for output
-	if (base64_encode_length(data_len) > text_len)
+	if (esp_base64_encode_length(data_len) > text_len)
 		return 0;
 
 	const uint8_t *data = (const uint8_t*)data_;
@@ -97,9 +97,9 @@ int ICACHE_FLASH_ATTR base64_encode(const void *data_, size_t data_len,
 
 
 /*
- * base64_decode_length() implementation.
+ * esp_base64_decode_length() implementation.
  */
-size_t ICACHE_FLASH_ATTR base64_decode_length(const char *text, size_t text_len)
+size_t ICACHE_FLASH_ATTR esp_base64_decode_length(const char *text, size_t text_len)
 {
 	if (!text_len)
 		return 0; // nothing to decode
@@ -117,16 +117,16 @@ size_t ICACHE_FLASH_ATTR base64_decode_length(const char *text, size_t text_len)
 
 
 /*
- * base64_decode() implementation.
+ * esp_base64_decode() implementation.
  */
-int ICACHE_FLASH_ATTR base64_decode(const char *text, size_t text_len,
-                                    void *data_base, size_t data_len)
+int ICACHE_FLASH_ATTR esp_base64_decode(const char *text, size_t text_len,
+                                        void *data_base, size_t data_len)
 {
 	if (!text_len || text_len%4)
 		return 0; // nothing to decode
 
 	// check we have enough space for output
-	if (base64_decode_length(text, text_len) > data_len)
+	if (esp_base64_decode_length(text, text_len) > data_len)
 		return 0;
 
 	uint8_t *data = (uint8_t*)data_base;

--- a/firmware-src/sources/base64.h
+++ b/firmware-src/sources/base64.h
@@ -22,10 +22,10 @@
  * @param[in] text_len Output buffer length in bytes.
  * @return Number of bytes written to output buffer.
  */
-int base64_encode(const void *data,
-                  size_t data_len,
-                  char *text,
-                  size_t text_len);
+int esp_base64_encode(const void *data,
+                      size_t data_len,
+                      char *text,
+                      size_t text_len);
 
 
 /**
@@ -33,7 +33,7 @@ int base64_encode(const void *data,
  * @param[in] data_len Binary data length in bytes.
  * @return `Base64` encoded text length in bytes.
  */
-size_t base64_encode_length(size_t data_len);
+size_t esp_base64_encode_length(size_t data_len);
 
 
 /**
@@ -47,10 +47,10 @@ size_t base64_encode_length(size_t data_len);
  * @param[in] data_len Output buffer length in bytes.
  * @return Number of bytes written to output buffer.
  */
-int base64_decode(const char *text,
-                  size_t text_len,
-                  void *data,
-                  size_t data_len);
+int esp_base64_decode(const char *text,
+                      size_t text_len,
+                      void *data,
+                      size_t data_len);
 
 
 /**
@@ -62,6 +62,6 @@ int base64_decode(const char *text,
  * @param[in] text_len Encoded text length in bytes.
  * @return Decoded binary data length in bytes.
  */
-size_t base64_decode_length(const char *text, size_t text_len);
+size_t esp_base64_decode_length(const char *text, size_t text_len);
 
 #endif /* _DATAENCODEBASE64_H_ */

--- a/firmware-src/sources/dhconnector.c
+++ b/firmware-src/sources/dhconnector.c
@@ -303,8 +303,11 @@ LOCAL void ICACHE_FLASH_ATTR set_state(CONNECTION_STATE state) {
 	mConnectionState = state;
 	switch(state) {
 	case CS_DISCONNECT:
+#ifdef DH_USE_SSL
+		// detect secure schemes (HTTPS or WSS)
 		mDHSecure = (0 == os_strncmp(dhsettings_get_devicehive_server(), "https://", 8))
 		         || (0 == os_strncmp(dhsettings_get_devicehive_server(), "wss://", 6));
+#endif // DH_USE_SSL
 
 		if(os_strncmp(dhsettings_get_devicehive_server(), "ws://", 5) == 0 ||
 				os_strncmp(dhsettings_get_devicehive_server(), "wss://", 6) == 0 ) {

--- a/firmware-src/sources/dhdata.c
+++ b/firmware-src/sources/dhdata.c
@@ -22,7 +22,7 @@
 
 int ICACHE_FLASH_ATTR dhdata_encode(const char *data, unsigned int datalen, char *out, unsigned int outlen) {
 #ifdef DATAENCODEBASE64
-	return base64_encode(data, datalen, out, outlen);
+	return esp_base64_encode(data, datalen, out, outlen);
 #else
 	if(datalen*2 > outlen || datalen == 0)
 		return 0;
@@ -38,7 +38,7 @@ int ICACHE_FLASH_ATTR dhdata_encode(const char *data, unsigned int datalen, char
 
 int ICACHE_FLASH_ATTR dhdata_decode(const char *data, unsigned int datalen, char *out, unsigned int outlen) {
 #ifdef DATAENCODEBASE64
-	return base64_decode(data, datalen, out, outlen);
+	return esp_base64_decode(data, datalen, out, outlen);
 #else
 	if(datalen % 2 || outlen < datalen / 2 || datalen == 0)
 		return 0;

--- a/firmware-src/sources/dhutils.c
+++ b/firmware-src/sources/dhutils.c
@@ -152,7 +152,10 @@ int ICACHE_FLASH_ATTR hexToByte(const char *hex, uint8_t *val_out)
 
 const char *ICACHE_FLASH_ATTR find_http_responce_code(const char *data, unsigned short len) {
 	unsigned short pos = sizeof(uint32);
-	if(len > sizeof(uint32) && *(uint32 *) data == 0x50545448) { // HTTP
+	if(len > sizeof(uint32) && data[0]=='H'
+	                        && data[1]=='T'
+	                        && data[2]=='T'
+	                        && data[3]=='P') {// *(uint32 *) data == 0x50545448) { // HTTP
 		while (pos < len)
 			if(data[pos++] == ' ')
 				break;

--- a/firmware-src/sources/user_config.h
+++ b/firmware-src/sources/user_config.h
@@ -37,6 +37,7 @@
 #define HTTPD_PORT 80
 
 // customize supported devices (compile time)
+#ifndef DH_NO_IMPLICIT_DEVICES
 #define DH_DEVICE_DS18B20
 #define DH_DEVICE_DHT11
 #define DH_DEVICE_DHT22
@@ -60,6 +61,7 @@
 #define DH_DEVICE_MAX6675
 #define DH_DEVICE_MAX31855
 #define DH_DEVICE_TM1637
+#endif // DH_NO_IMPLICIT_DEVICES
 
 // customize device commands (compile time)
 #define DH_COMMANDS_DS18B20
@@ -94,7 +96,5 @@
 #define DH_COMMANDS_I2C      // enable I2C commands
 #define DH_COMMANDS_SPI      // enable SPI commands
 #define DH_COMMANDS_ONEWIRE  // enable onewire commands
-
-// TODO: customize device list
 
 #endif /* _USER_CONFIG_H_ */


### PR DESCRIPTION
There is still an issue with supported server's certificate. ESP8266 firmware works with key size of 1024bit. If key size is 2048 or more the `espconn_secure_connect()` ends up with `ESPCONN_RST` error.